### PR TITLE
Hotfix - jQuery

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,8 +8,12 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 
-require("bootstrap")
-require("jquery")
+//Import Bootstrap and Dependencies
+require('bootstrap')
+//Set $ with jQuery
+global.$ = require("jquery")
+
+
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.


### PR DESCRIPTION
Resolvido um bug no qual o WebPacker importava o jQuery, mas não o instanciava ao símbolo '$' (que é usado para "chamar" o jQuery no JS), impossibilitando o seu uso.

(Fiz outro PR, porque o anterior puxou os commits de outra branch...)